### PR TITLE
Remove placeholder contact page

### DIFF
--- a/apps/trialanderror.org/src/app/contact/pageX.tsx
+++ b/apps/trialanderror.org/src/app/contact/pageX.tsx
@@ -1,7 +1,0 @@
-export default async function ContactPage() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <p>Nothing to see here yet!</p>
-    </div>
-  )
-}


### PR DESCRIPTION
The current website links out to `https://journal.trialanderror.org/legal-status` in the footer, and the contact page remains unused. Given there is no content in it, I suggest removing it.
