### PR TITLE
Add RSS link to layout

### DIFF
--- a/apps/trialanderror.org/src/app/layout.tsx
+++ b/apps/trialanderror.org/src/app/layout.tsx
@@ -52,6 +52,7 @@ export default function RootLayout({
 				/>
 				<link rel="manifest" href="/site.webmanifest" />
 				<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#002642" />
+				<link rel="alternate" type="application/rss+xml" title="Journal of Trial and Error (JOTE)" href="/api/rss" />
 				<meta name="msapplication-TileColor" content="#002642" />
 				<meta name="theme-color" content="#ffffff" />
 			</head>

--- a/apps/trialanderror.org/src/app/layout.tsx
+++ b/apps/trialanderror.org/src/app/layout.tsx
@@ -52,7 +52,12 @@ export default function RootLayout({
 				/>
 				<link rel="manifest" href="/site.webmanifest" />
 				<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#002642" />
-				<link rel="alternate" type="application/rss+xml" title="Journal of Trial and Error (JOTE)" href="/api/rss" />
+				<link
+					rel="alternate"
+					type="application/rss+xml"
+					title="Center of Trial and Error | RSS Feed"
+					href="/api/rss"
+				/>
 				<meta name="msapplication-TileColor" content="#002642" />
 				<meta name="theme-color" content="#ffffff" />
 			</head>


### PR DESCRIPTION
This helps promote discoverability of the RSS feed that is available for the trial and error website.

Please double check the title, as I am unsure that applies well here 😊 I tested the `api/rss` route on the live page, but I may of course have overlooked something.
